### PR TITLE
fix : potential nil err while w is not created successfully

### DIFF
--- a/easyssh.go
+++ b/easyssh.go
@@ -32,6 +32,9 @@ type MakeConfig struct {
 	Key      string
 	Port     string
 	Password string
+	// Timeout is the maximum amount of time for the TCP connection to establish.
+	// A Timeout of zero means no timeout.
+	Timeout time.Duration
 }
 
 // returns ssh.Signer from user you running app home path + cutted key path.
@@ -76,8 +79,9 @@ func (ssh_conf *MakeConfig) connect() (*ssh.Session, error) {
 	}
 
 	config := &ssh.ClientConfig{
-		User: ssh_conf.User,
-		Auth: auths,
+		User:    ssh_conf.User,
+		Auth:    auths,
+		Timeout: ssh_conf.Timeout,
 	}
 
 	client, err := ssh.Dial("tcp", ssh_conf.Server+":"+ssh_conf.Port, config)

--- a/easyssh.go
+++ b/easyssh.go
@@ -203,17 +203,19 @@ func (ssh_conf *MakeConfig) Scp(sourceFile string, etargetFile string) error {
 	}
 
 	go func() {
-		w, _ := session.StdinPipe()
+		w, err := session.StdinPipe()
+		if err != nil {
+			return
+		}
+		defer w.Close()
 
 		fmt.Fprintln(w, "C0644", srcStat.Size(), targetFile)
 
 		if srcStat.Size() > 0 {
 			io.Copy(w, src)
 			fmt.Fprint(w, "\x00")
-			w.Close()
 		} else {
 			fmt.Fprint(w, "\x00")
-			w.Close()
 		}
 	}()
 


### PR DESCRIPTION
if `w` is nil,  nil error will be throwed out while calling `fmt.Fprintln` and `io.Copy`